### PR TITLE
Initialize collection baseline to avoid false collection events and fix Gen3 memory addresses

### DIFF
--- a/tracker_gui.py
+++ b/tracker_gui.py
@@ -470,44 +470,46 @@ class PokemonMemoryReader:
         "pokemon_ruby": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_flags": "0x202F900",
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_sapphire": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_flags": "0x202F900",
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_emerald": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_firered": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_leafgreen": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
     }
@@ -869,6 +871,7 @@ class AchievementTracker:
         self._collection_queue: queue.Queue = queue.Queue()
         self._last_party: List[Dict] = []
         self._last_pokedex: List[int] = []
+        self._collection_baseline_initialized = False
         self._derived_checker: Optional[DerivedAchievementChecker] = None
     
     def load_game(self, game_name: str, achievements_file: Path) -> bool:
@@ -892,7 +895,10 @@ class AchievementTracker:
             
             self.game_name = game_name
             self.game_id = self.GAME_IDS.get(game_name)
-            
+            self._last_party = []
+            self._last_pokedex = []
+            self._collection_baseline_initialized = False
+
             # Initialize derived achievement checker
             if GAME_CONFIGS_AVAILABLE and self.game_name:
                 try:
@@ -1294,6 +1300,13 @@ class AchievementTracker:
         # Read current party
         current_party = self.pokemon_reader.read_party(self.game_name)
         
+        # First read after game load/start establishes baseline only
+        if not self._collection_baseline_initialized:
+            self._last_pokedex = current_pokedex
+            self._last_party = current_party
+            self._collection_baseline_initialized = True
+            return
+
         # Find new catches
         new_catches = [p for p in current_pokedex if p not in self._last_pokedex]
         
@@ -2083,6 +2096,7 @@ class PokeAchieveGUI:
                 self.tracker.game_id = None
                 self.tracker._last_party = []
                 self.tracker._last_pokedex = []
+                self.tracker._collection_baseline_initialized = False
 
                 self.game_label.configure(text="Game: None")
                 self.progress_label.configure(text="0/0 (0%) - 0/0 pts")


### PR DESCRIPTION
### Motivation
- Correct Gen 3 memory map entries so pokedex and party reads use the proper addresses for Ruby/Sapphire/Emerald/FireRed/LeafGreen.  
- Prevent spurious collection/party change events from being emitted on the first memory read after loading a game by establishing a baseline state.  

### Description
- Updated Gen 3 `GAME_CONFIGS` entries to use explicit `pokedex_seen` and `pokedex_caught` addresses and corrected `party_count`/`party_start` addresses (addresses normalized to `0x020...`).  
- Added a `_collection_baseline_initialized` boolean to `AchievementTracker` and reset it in `load_game` and when clearing app data via the GUI.  
- Modified `check_collection` to treat the first read after load/start as a baseline by saving `current_pokedex` and `current_party` and returning without queuing collection updates.  
- Ensure `load_game` clears `_last_party` and `_last_pokedex` on game load so state is deterministic after a new game is loaded.  

### Testing
- Ran the project's automated test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87c4e5e3083339b85160f342ba8ea)