### PR TITLE
Stabilize collection detection and update Gen 3 memory addresses

### DIFF
--- a/tracker_gui.py
+++ b/tracker_gui.py
@@ -470,44 +470,46 @@ class PokemonMemoryReader:
         "pokemon_ruby": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_flags": "0x202F900",
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_sapphire": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_flags": "0x202F900",
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_emerald": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_firered": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
         "pokemon_leafgreen": {
             "gen": 3,
             "max_pokemon": 386,
-            "pokedex_seen": "0x202F900",
-            "pokedex_caught": "0x202F900",  # TODO: Find correct caught address for Gen 3
-            "party_count": "0x20244E0",
-            "party_start": "0x20244E8",
+            "pokedex_seen": "0x02024C0C",
+            "pokedex_caught": "0x02024D0C",
+            "party_count": "0x02024284",
+            "party_start": "0x02024284",
             "party_slot_size": 100,
         },
     }
@@ -869,6 +871,7 @@ class AchievementTracker:
         self._collection_queue: queue.Queue = queue.Queue()
         self._last_party: List[Dict] = []
         self._last_pokedex: List[int] = []
+        self._collection_baseline_initialized = False
         self._derived_checker: Optional[DerivedAchievementChecker] = None
     
     def load_game(self, game_name: str, achievements_file: Path) -> bool:
@@ -892,7 +895,10 @@ class AchievementTracker:
             
             self.game_name = game_name
             self.game_id = self.GAME_IDS.get(game_name)
-            
+            self._last_party = []
+            self._last_pokedex = []
+            self._collection_baseline_initialized = False
+
             # Initialize derived achievement checker
             if GAME_CONFIGS_AVAILABLE and self.game_name:
                 try:
@@ -1294,8 +1300,28 @@ class AchievementTracker:
         # Read current party
         current_party = self.pokemon_reader.read_party(self.game_name)
         
+        # First read after game load/start establishes baseline only
+        if not self._collection_baseline_initialized:
+            self._last_pokedex = current_pokedex
+            self._last_party = current_party
+            self._collection_baseline_initialized = True
+            return
+
         # Find new catches
         new_catches = [p for p in current_pokedex if p not in self._last_pokedex]
+
+        # Guard against bad memory reads causing impossible bulk catch spikes.
+        # In normal gameplay, catches increment gradually (typically 0-1 per poll).
+        if len(new_catches) > 6:
+            log_event(
+                logging.WARNING,
+                "collection_spike_ignored",
+                game=self.game_name,
+                spike_count=len(new_catches),
+            )
+            self._last_pokedex = current_pokedex
+            self._last_party = current_party
+            return
         
         # Find party changes
         party_changes = []
@@ -2083,6 +2109,7 @@ class PokeAchieveGUI:
                 self.tracker.game_id = None
                 self.tracker._last_party = []
                 self.tracker._last_pokedex = []
+                self.tracker._collection_baseline_initialized = False
 
                 self.game_label.configure(text="Game: None")
                 self.progress_label.configure(text="0/0 (0%) - 0/0 pts")


### PR DESCRIPTION
### Motivation
- Fix incorrect/legacy memory addresses for Gen 3 games and standardize pokedex/party keys so the reader returns correct seen/caught and party data.
- Prevent spurious collection events on tracker startup caused by initial memory reads or bad memory spikes.
- Ensure tracker state is reset consistently when loading a game or clearing app data so baseline logic behaves predictably.

### Description
- Updated Gen 3 game configs (Ruby, Sapphire, Emerald, FireRed, LeafGreen) to use new `pokedex_seen`, `pokedex_caught`, `party_count`, and `party_start` addresses and kept `party_slot_size` at 100, replacing older/incorrect keys and values.
- Added `_collection_baseline_initialized` flag to `AchievementTracker` and initialize/reset it in `__init__`, `load_game`, and when clearing app data to mark whether the first poll has been used as a baseline.
- On first `check_collection()` after load/start, record the current pokedex and party as the baseline and return without emitting collection events.
- Added a guard to ignore improbable bulk catch spikes (more than 6 new catches in a single poll) with a warning log event and an update of the baseline to avoid flooding updates from bad reads.

### Testing
- Ran the project automated test suite; all tests completed successfully.
- Executed tracker smoke tests simulating memory reads to verify baseline establishment and spike protection, and observed expected behavior (no immediate spurious collection events and spikes are ignored).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87c4e5e3083339b85160f342ba8ea)