### PR TITLE
Tighten API fallback and limit legendary unlock spikes

### DIFF
--- a/tracker_gui.py
+++ b/tracker_gui.py
@@ -219,6 +219,12 @@ class PokeAchieveAPI:
         if success:
             return True, data
 
+        # Only try legacy routes when the tracker endpoint is unavailable.
+        # Avoid masking actionable auth/validation errors behind legacy failures.
+        status = data.get("status") if isinstance(data, dict) else None
+        if status not in {404, 405}:
+            return False, data
+
         # Backwards compatibility with legacy backend route
         legacy_payload = {
             "game_id": game_id,
@@ -930,7 +936,12 @@ class AchievementTracker:
 
         config = self.validation_profiles if isinstance(self.validation_profiles, dict) else {}
         default_by_gen = config.get("default_by_gen", {}) if isinstance(config.get("default_by_gen", {}), dict) else {}
-        fallback_defaults = {"max_unlocks_per_poll": 3, "max_new_catches_per_poll": 5, "max_major_unlocks_per_poll": 2}
+        fallback_defaults = {
+            "max_unlocks_per_poll": 3,
+            "max_new_catches_per_poll": 5,
+            "max_major_unlocks_per_poll": 2,
+            "max_legendary_unlocks_per_poll": 1,
+        }
 
         raw_default = default_by_gen.get(str(gen), {})
         profile = dict(raw_default) if isinstance(raw_default, dict) else dict(fallback_defaults)
@@ -1105,6 +1116,7 @@ class AchievementTracker:
         profile = self._get_validation_profile()
         candidates_this_poll = 0
         major_candidates_this_poll = 0
+        legendary_candidates_this_poll = 0
 
         for achievement in self.achievements:
             if achievement.unlocked:
@@ -1140,6 +1152,15 @@ class AchievementTracker:
                     if major_candidates_this_poll > profile.get("max_major_unlocks_per_poll", 2):
                         self._record_anomaly("major_unlock_spike_ignored", game=self.game_name, category=achievement.category, count=major_candidates_this_poll, threshold=profile.get("max_major_unlocks_per_poll", 2))
                         log_event(logging.WARNING, "major_unlock_spike_ignored", game=self.game_name, category=achievement.category, count=major_candidates_this_poll, threshold=profile.get("max_major_unlocks_per_poll", 2))
+                        self._unlock_streaks[achievement.id] = 0
+                        continue
+
+                if achievement.category == "legendary":
+                    legendary_candidates_this_poll += 1
+                    max_legendary = profile.get("max_legendary_unlocks_per_poll", 1)
+                    if legendary_candidates_this_poll > max_legendary:
+                        self._record_anomaly("legendary_unlock_spike_ignored", game=self.game_name, count=legendary_candidates_this_poll, threshold=max_legendary)
+                        log_event(logging.WARNING, "legendary_unlock_spike_ignored", game=self.game_name, count=legendary_candidates_this_poll, threshold=max_legendary)
                         self._unlock_streaks[achievement.id] = 0
                         continue
 


### PR DESCRIPTION
### Motivation
- Reduce clusters of false-positive unlocks (notably multiple legendary unlocks) caused by transient memory noise during polling.
- Prevent legitimate API errors (for example auth/validation failures) from being masked by automatic fallback to legacy endpoints.

### Description
- Restrict the `post_unlock` fallback so the tracker only retries the legacy `POST /progress/update` when the primary `POST /api/tracker/unlock` returned an unavailable status (`404`/`405`) instead of masking other errors. (edited in `tracker_gui.py` in `post_unlock`)
- Add a new validation default `max_legendary_unlocks_per_poll` (default `1`) in `_get_validation_profile` to allow per-game tuning of legendary unlock burst thresholds. (edited in `tracker_gui.py` in `_get_validation_profile`)
- Track `legendary_candidates_this_poll` inside `check_achievements` and short-circuit/record an anomaly when the per-poll legendary threshold is exceeded, resetting streaks to prevent spurious unlocks. (edited in `tracker_gui.py` in `check_achievements`)

### Testing
- Ran `python -m py_compile tracker_gui.py` to verify syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5021db308333b8f6091cae3253a0)