### PR TITLE
Add unlock warmup/startup baseline and legendary limits; tighten legacy unlock fallback

### DIFF
--- a/tracker_gui.py
+++ b/tracker_gui.py
@@ -219,6 +219,12 @@ class PokeAchieveAPI:
         if success:
             return True, data
 
+        # Only try legacy routes when the tracker endpoint is unavailable.
+        # Avoid masking actionable auth/validation errors behind legacy failures.
+        status = data.get("status") if isinstance(data, dict) else None
+        if status != 404:
+            return False, data
+
         # Backwards compatibility with legacy backend route
         legacy_payload = {
             "game_id": game_id,
@@ -906,6 +912,10 @@ class AchievementTracker:
         self._collection_baseline_initialized = False
         self._unlock_streaks: Dict[str, int] = {}
         self._bad_read_streak = 0
+        self._achievement_poll_count = 0
+        self._warmup_logged = False
+        self._startup_baseline_captured = False
+        self._startup_lockout_ids: set[str] = set()
         self.validation_profiles: Dict[str, object] = {}
         self.recent_anomalies: List[Dict] = []
         self._derived_checker: Optional[DerivedAchievementChecker] = None
@@ -930,7 +940,13 @@ class AchievementTracker:
 
         config = self.validation_profiles if isinstance(self.validation_profiles, dict) else {}
         default_by_gen = config.get("default_by_gen", {}) if isinstance(config.get("default_by_gen", {}), dict) else {}
-        fallback_defaults = {"max_unlocks_per_poll": 3, "max_new_catches_per_poll": 5, "max_major_unlocks_per_poll": 2}
+        fallback_defaults = {
+            "max_unlocks_per_poll": 3,
+            "max_new_catches_per_poll": 5,
+            "max_major_unlocks_per_poll": 2,
+            "max_legendary_unlocks_per_poll": 1,
+            "unlock_warmup_polls": 4,
+        }
 
         raw_default = default_by_gen.get(str(gen), {})
         profile = dict(raw_default) if isinstance(raw_default, dict) else dict(fallback_defaults)
@@ -1034,6 +1050,10 @@ class AchievementTracker:
             self._collection_baseline_initialized = False
             self._unlock_streaks = {}
             self._bad_read_streak = 0
+            self._achievement_poll_count = 0
+            self._warmup_logged = False
+            self._startup_baseline_captured = False
+            self._startup_lockout_ids = set()
 
             validation = self.pokemon_reader.validate_memory_profile(game_name)
             log_event(logging.INFO, "memory_profile_validation", game=game_name, ok=validation.get("ok"), failures=validation.get("failures", []))
@@ -1103,8 +1123,21 @@ class AchievementTracker:
         """Check all achievements, return newly unlocked ones"""
         newly_unlocked = []
         profile = self._get_validation_profile()
+        self._achievement_poll_count += 1
+        warmup_polls = max(0, int(profile.get("unlock_warmup_polls", 4)))
+        if self._achievement_poll_count <= warmup_polls:
+            if not self._warmup_logged:
+                log_event(logging.INFO, "unlock_warmup_active", game=self.game_name, polls=warmup_polls)
+                self._warmup_logged = True
+            return []
+
+        baseline_mode = not self._startup_baseline_captured
+        if baseline_mode:
+            self._startup_lockout_ids = set()
+
         candidates_this_poll = 0
         major_candidates_this_poll = 0
+        legendary_candidates_this_poll = 0
 
         for achievement in self.achievements:
             if achievement.unlocked:
@@ -1127,6 +1160,16 @@ class AchievementTracker:
             else:
                 unlocked = self._check_derived_achievement(achievement)
             
+            if baseline_mode:
+                if unlocked:
+                    self._startup_lockout_ids.add(achievement.id)
+                continue
+
+            if achievement.id in self._startup_lockout_ids:
+                if not unlocked:
+                    self._startup_lockout_ids.discard(achievement.id)
+                continue
+
             if unlocked:
                 candidates_this_poll += 1
                 if candidates_this_poll > profile["max_unlocks_per_poll"]:
@@ -1143,6 +1186,15 @@ class AchievementTracker:
                         self._unlock_streaks[achievement.id] = 0
                         continue
 
+                if achievement.category == "legendary":
+                    legendary_candidates_this_poll += 1
+                    max_legendary = profile.get("max_legendary_unlocks_per_poll", 1)
+                    if legendary_candidates_this_poll > max_legendary:
+                        self._record_anomaly("legendary_unlock_spike_ignored", game=self.game_name, count=legendary_candidates_this_poll, threshold=max_legendary)
+                        log_event(logging.WARNING, "legendary_unlock_spike_ignored", game=self.game_name, count=legendary_candidates_this_poll, threshold=max_legendary)
+                        self._unlock_streaks[achievement.id] = 0
+                        continue
+
                 self._unlock_streaks[achievement.id] = self._unlock_streaks.get(achievement.id, 0) + 1
                 # Require two consecutive positive polls to avoid transient memory-read false positives.
                 if self._unlock_streaks[achievement.id] >= 2:
@@ -1154,6 +1206,12 @@ class AchievementTracker:
             else:
                 self._unlock_streaks[achievement.id] = 0
         
+        if baseline_mode:
+            self._startup_baseline_captured = True
+            if self._startup_lockout_ids:
+                log_event(logging.INFO, "unlock_startup_lockout", game=self.game_name, count=len(self._startup_lockout_ids))
+            return []
+
         return newly_unlocked
     
     def _check_derived_achievement(self, achievement: Achievement) -> bool:
@@ -2482,6 +2540,10 @@ class PokeAchieveGUI:
                 self.tracker._last_pokedex = []
                 self.tracker._collection_baseline_initialized = False
                 self.tracker._unlock_streaks = {}
+                self.tracker._achievement_poll_count = 0
+                self.tracker._warmup_logged = False
+                self.tracker._startup_baseline_captured = False
+                self.tracker._startup_lockout_ids = set()
                 self._sent_event_ids = set()
                 self._save_sent_events()
                 self._set_api_status("Not configured" if not self.api else "Configured")


### PR DESCRIPTION
### Motivation

- Reduce false-positive unlocks immediately after tracker start by introducing a warmup period controlled by `unlock_warmup_polls`. 
- Prevent large spikes of simultaneous unlocks (especially legendaries) from being sent by adding per-poll caps and stricter handling for `legendary` category achievements. 
- Avoid masking actionable API errors by only falling back to legacy unlock routes when the primary tracker endpoint returns a 404.

### Description

- Added internal poll tracking fields (`_achievement_poll_count`, `_warmup_logged`, `_startup_baseline_captured`, `_startup_lockout_ids`) and reset them when loading achievements or clearing app data. 
- Implemented a warmup phase in `check_achievements` which returns early for the first `unlock_warmup_polls` polls and logs `unlock_warmup_active`. 
- Added a startup baseline mode that collects currently-true achievements into `_startup_lockout_ids` during the first post-warmup poll to avoid immediate unlocks, and emits `unlock_startup_lockout` if any were captured. 
- Enforced per-poll caps including a new `max_legendary_unlocks_per_poll` and logic to record/log `legendary_unlock_spike_ignored`; kept existing caps for `max_unlocks_per_poll` and `max_major_unlocks_per_poll`. 
- Modified `PokeAchieveAPI.post_unlock` so the legacy `/progress/update` route is only attempted when the primary unlock response indicates a 404, thereby surfacing auth/validation errors instead of silently falling back. 
- Persisted warmup/startup state resets in the GUI clear-data flow so restarting the app truly starts fresh.

### Testing

- Ran the project's automated unit tests (tracker and API-related tests) and static checks against the modified modules; the test suite completed without failures. 
- Performed automated smoke validation of `check_achievements` behavior under simulated poll sequences to confirm warmup/lockout and legendary cap logic triggered expected log events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5021db308333b8f6091cae3253a0)