### PR TITLE
Fix Gen 1 party species decoding and load hunt catalog asynchronously to reduce startup jank

### DIFF
--- a/scripts/validate_reporting.py
+++ b/scripts/validate_reporting.py
@@ -156,6 +156,37 @@ class ReportingValidationTests(unittest.TestCase):
         self.assertTrue(self.tracker._is_plausible_badge_byte(78, generation=3))
         self.assertFalse(self.tracker._is_plausible_badge_byte(78, generation=1))
 
+    def test_gen1_party_internal_species_ids_map_to_national_dex(self):
+        class PartyRetroGen1:
+            def read_memory(self, addr: str, num_bytes: int = 1):
+                address = int(addr, 16)
+                if num_bytes == 1:
+                    if address == 0xD163:
+                        return 1
+                    # Party species list entry #1 is Squirtle in Gen1 internal ordering.
+                    if address == 0xD164:
+                        return 177
+                    if address == 0xD16B:
+                        return 177
+                    return 0
+                if num_bytes == 44:
+                    slot = [0] * 44
+                    slot[0] = 177
+                    slot[3] = 5
+                    return slot
+                return [0] * int(num_bytes)
+
+        reader = self.tracker.pokemon_reader
+        original_retro = reader.retroarch
+        try:
+            reader.retroarch = PartyRetroGen1()
+            party = reader.read_party("Pokemon Red")
+            self.assertEqual(len(party), 1)
+            self.assertEqual(party[0]["id"], 7)
+            self.assertEqual(party[0]["level"], 5)
+        finally:
+            reader.retroarch = original_retro
+
     def test_gen3_gym_checks_require_contiguous_badge_progression(self):
         gym6 = Achievement(
             id="emerald_gym_6",

--- a/tracker_gui.py
+++ b/tracker_gui.py
@@ -1541,9 +1541,41 @@ class PokemonMemoryReader:
                 internal_species_map=len(self._gen3_internal_to_national),
             )
 
+    # Gen 1 (RBY) uses internal species ordering in party data.
+    # Source: pret/pokered data/pokemon/dex_order.asm
+    GEN1_INTERNAL_TO_NATIONAL = {
+        1: 112, 2: 115, 3: 32, 4: 35, 5: 21, 6: 100, 7: 34, 8: 80, 9: 2, 10: 103,
+        11: 108, 12: 102, 13: 88, 14: 94, 15: 29, 16: 31, 17: 104, 18: 111, 19: 131,
+        20: 59, 21: 151, 22: 130, 23: 90, 24: 72, 25: 92, 26: 123, 27: 120, 28: 9,
+        29: 127, 30: 114, 33: 58, 34: 95, 35: 22, 36: 16, 37: 79, 38: 64, 39: 75,
+        40: 113, 41: 67, 42: 122, 43: 106, 44: 107, 45: 24, 46: 47, 47: 54, 48: 96,
+        49: 76, 51: 126, 53: 125, 54: 82, 55: 109, 57: 56, 58: 86, 59: 50, 60: 128,
+        64: 83, 65: 48, 66: 149, 70: 84, 71: 60, 72: 124, 73: 146, 74: 144, 75: 145,
+        76: 132, 77: 52, 78: 98, 82: 37, 83: 38, 84: 25, 85: 26, 88: 147, 89: 148,
+        90: 140, 91: 141, 92: 116, 93: 117, 96: 27, 97: 28, 98: 138, 99: 139,
+        100: 39, 101: 40, 102: 133, 103: 136, 104: 135, 105: 134, 106: 66, 107: 41,
+        108: 23, 109: 46, 110: 61, 111: 62, 112: 13, 113: 14, 114: 15, 116: 85,
+        117: 57, 118: 51, 119: 49, 120: 87, 123: 10, 124: 11, 125: 12, 126: 68,
+        128: 55, 129: 97, 130: 42, 131: 150, 132: 143, 133: 129, 136: 89, 138: 99,
+        139: 91, 141: 101, 142: 36, 143: 110, 144: 53, 145: 105, 147: 93, 148: 63,
+        149: 65, 150: 17, 151: 18, 152: 121, 153: 1, 154: 3, 155: 73, 157: 118,
+        158: 119, 163: 77, 164: 78, 165: 19, 166: 20, 167: 33, 168: 30, 169: 74,
+        170: 137, 171: 142, 173: 81, 176: 4, 177: 7, 178: 5, 179: 8, 180: 6,
+        185: 43, 186: 44, 187: 45, 188: 69, 189: 70, 190: 71,
+    }
+
     def get_pokemon_name(self, pokemon_id: int) -> str:
         """Get Pokemon name from ID"""
         return self.POKEMON_NAMES.get(pokemon_id, f"Pokemon #{pokemon_id}")
+
+    def _resolve_gen1_species_id(self, raw_species_id: int) -> int:
+        """Convert Gen 1 internal species IDs to National Dex IDs when possible."""
+        try:
+            species_int = int(raw_species_id) & 0xFF
+        except (TypeError, ValueError):
+            return 0
+        mapped = self.GEN1_INTERNAL_TO_NATIONAL.get(species_int)
+        return int(mapped) if isinstance(mapped, int) and mapped > 0 else int(species_int)
 
     def get_last_party_read_meta(self) -> Dict[str, object]:
         """Return metadata from the most recent party read attempt."""
@@ -3522,6 +3554,8 @@ class PokemonMemoryReader:
                 if all(isinstance(v, int) and 0 <= int(v) <= 0xFF for v in slot_data[:slot_size]):
                     slot_bytes = [int(v) & 0xFF for v in slot_data[:slot_size]]
                     species_id = int(slot_bytes[0])
+                    if int(gen) == 1:
+                        species_id = self._resolve_gen1_species_id(species_id)
 
                     if int(gen) == 2:
                         # GSC party struct: MON_LEVEL at 0x1F, MON_DVS at 0x15-0x16.
@@ -3555,11 +3589,11 @@ class PokemonMemoryReader:
                 continue
 
             if int(gen) == 1:
-                # Gen 1 slot species bytes are internal IDs. Read the party species list for Dex IDs.
+                # Gen 1 party species list bytes are also internal IDs on most cores.
                 species_list_addr = hex(int(party_count_addr, 16) + 1 + i)
                 species_list_value = self.retroarch.read_memory(species_list_addr)
                 if isinstance(species_list_value, int):
-                    species_list_id = int(species_list_value) & 0xFF
+                    species_list_id = self._resolve_gen1_species_id(species_list_value)
                     max_species = int(config.get("max_pokemon", 151) or 151)
                     if 1 <= species_list_id <= max_species:
                         species_id = species_list_id
@@ -5756,9 +5790,10 @@ class PokeAchieveGUI:
             "Hatching Egg Hunt",
         ]
         self._hunt_game_options = self._build_hunt_game_options()
-        self._hunt_encounter_catalog: Dict[str, Dict[str, Dict[str, Any]]] = self._build_hunt_encounter_catalog()
-        self._hunt_route_options: Dict[str, List[str]] = self._build_default_hunt_route_options()
-        self._hunt_fishing_options: Dict[str, List[str]] = self._build_default_hunt_fishing_options()
+        # Build these lazily to keep initial window open responsive.
+        self._hunt_encounter_catalog: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        self._hunt_route_options: Dict[str, List[str]] = {}
+        self._hunt_fishing_options: Dict[str, List[str]] = {}
         self.hunt_mode_var = tk.StringVar(value=self._hunt_modes[0])
         self.hunt_game_var = tk.StringVar(value=self._hunt_game_options[0] if self._hunt_game_options else "")
         self.hunt_route_var = tk.StringVar(value="Any Soft Reset")
@@ -5808,8 +5843,26 @@ class PokeAchieveGUI:
         self._hunt_pause_btn: Optional[ttk.Button] = None
 
         self._build_ui()
+        self.root.after(10, self._prime_hunt_catalog_async)
         self._start_status_check()
         self.root.after(250, self._maybe_run_setup_wizard)
+
+    def _prime_hunt_catalog_async(self):
+        """Load hunt encounter catalog in a worker thread to reduce startup jank."""
+
+        def worker():
+            catalog = self._build_hunt_encounter_catalog()
+            self._hunt_encounter_catalog = catalog
+            self._hunt_route_options = self._build_default_hunt_route_options()
+            self._hunt_fishing_options = self._build_default_hunt_fishing_options()
+            self.root.after(0, self._apply_hunt_catalog_ready)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _apply_hunt_catalog_ready(self):
+        """Refresh hunt selectors once async catalog loading completes."""
+        self._update_hunt_mode_controls()
+        self._refresh_hunt_targets()
     
     def _configure_styles(self):
         """Apply a cleaner, modern ttk theme and spacing."""


### PR DESCRIPTION
### Motivation
- Party slot species read from Gen 1 games used internal RBY ordering which could be misinterpreted as wrong Dex IDs, causing caught/party mismatches in logs and API payloads.
- Building the full shiny-hunt encounter catalog synchronously at startup caused UI freeze/sluggishness when opening the tracker.

### Description
- Add a Gen 1 internal->national mapping table `GEN1_INTERNAL_TO_NATIONAL` and helper `_resolve_gen1_species_id` to `PokemonMemoryReader` to translate RBY internal species IDs to National Dex IDs (file: `tracker_gui.py`).
- Apply the Gen 1 conversion when decoding species from both slot bytes and the party species list bytes so party slot IDs render consistently for Gen 1 games (file: `tracker_gui.py`).
- Defer heavy hunt catalog construction by initializing hunt-related structures lazily and loading the catalog on a background thread using `_prime_hunt_catalog_async`, then refresh hunt controls on completion to keep the initial window responsive (file: `tracker_gui.py`).
- Add a regression test `test_gen1_party_internal_species_ids_map_to_national_dex` to `scripts/validate_reporting.py` that asserts an internal Squirtle ID maps to Dex #7 and verifies level parsing.

### Testing
- Compiled `tracker_gui.py` with `python -m py_compile tracker_gui.py` and the compile step succeeded.
- Ran the test harness `python scripts/validate_reporting.py` which executed the full suite including the new Gen 1 test; all tests passed (37 tests, OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc8a816248333b51f1bb450fec272)